### PR TITLE
Rename whitespace after control structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ php:
     whitespace_after_function_open:                   no_apply    # newline, no_space
     whitespace_after_function:                        no_apply    # newline, double_newline
     whitespace_before_control_structure_brace:        no_apply    # space, newline, no_space
+    whitespace_before_control_structure_parentheses:  no_apply    # no_space, whitespace
     whitespace_before_doc_asterisk:                   no_apply    # space
     whitespace_before_else:                           no_apply    # space, newline, no_space
     whitespace_before_function_brace:                 no_apply    # space, newline, no_space

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,6 @@ php:
     type_cast_inner_whitespace:                       no_apply    # whitespace, no_space
     use_quotes:                                       no_apply    # single_quotes, double_quotes
     variable_array_index_whitespace:                  no_apply    # whitespace, no_space
-    whitespace_after_control_structure:               no_apply    # no_space, whitespace
     whitespace_after_doc_asterisk:                    no_apply    # single_space, double_space, tab
     whitespace_after_else:                            no_apply    # space, newline, no_space
     whitespace_after_function_open:                   no_apply    # newline, no_space

--- a/template/codeoversight.yml
+++ b/template/codeoversight.yml
@@ -27,12 +27,12 @@ php:
     type_cast_inner_whitespace:                       no_apply    # whitespace, no_space
     use_quotes:                                       no_apply    # single_quotes, double_quotes
     variable_array_index_whitespace:                  no_apply    # whitespace, no_space
-    whitespace_after_control_structure:               no_apply    # no_space, whitespace
     whitespace_after_doc_asterisk:                    no_apply    # single_space, double_space, tab
     whitespace_after_else:                            no_apply    # space, newline, no_space
     whitespace_after_function_open:                   no_apply    # newline, no_space
     whitespace_after_function:                        no_apply    # newline, double_newline
     whitespace_before_control_structure_brace:        no_apply    # space, newline, no_space
+    whitespace_before_control_structure_parentheses:  no_apply    # no_space, whitespace
     whitespace_before_doc_asterisk:                   no_apply    # space
     whitespace_before_else:                           no_apply    # space, newline, no_space
     whitespace_before_function_brace:                 no_apply    # space, newline, no_space

--- a/wordpress/codeoversight.yml
+++ b/wordpress/codeoversight.yml
@@ -26,12 +26,12 @@ php:
     type_cast_inner_whitespace: no_space
     use_quotes: single_quotes
     variable_array_index_whitespace: whitespace
-    whitespace_after_control_structure: whitespace
     whitespace_after_doc_asterisk: single_space
     whitespace_after_else: space
     whitespace_after_function_open: no_space
     whitespace_after_function: newline
     whitespace_before_control_structure_brace: space
+    whitespace_before_control_structure_parentheses: whitespace
     whitespace_before_doc_asterisk: space
     whitespace_before_else: space
     whitespace_before_function_brace: space


### PR DESCRIPTION
Rename the code rule `whitespace_after_control_structure` to `whitespace_before_control_structure_parentheses`
